### PR TITLE
Fix runtime import and client stability issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,4 @@ Homepage = "https://github.com/huy746/ruyth-core"
 dependencies = { file = "requirements.txt" }
 
 [tool.setuptools.packages.find]
-include = ["ruythcore"]
+include = ["ruythcore*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,2 @@
-aiohttp
-asyncio
-websockets
-functools
-typing
-inspect
-dataclasses
-setuptools
-wheel
-twine
-yarl
+aiohttp>=3.8
+websockets>=10

--- a/ruythcore/client.py
+++ b/ruythcore/client.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from .gateway import Gateway
 from .http import HTTPClient
 from .commands import CommandManager
@@ -6,6 +7,7 @@ from .slash import SlashCommandManager
 from .events import EventHandler
 from .context import Context
 from .models import Message, User
+
 
 class Client:
     def __init__(self, token, intents=0, prefix="!"):
@@ -27,22 +29,49 @@ class Client:
     def slash_command(self, name=None, description=None):
         return self.slash.slash(name, description)
 
-    def event(self, name=None):
-        return self.events.on(name or "ready")
+    def event(self, func=None, name=None):
+        def decorator(handler):
+            event_name = name or self._event_name_from_handler(handler)
+            return self.events.on(event_name)(handler)
+
+        if callable(func):
+            return decorator(func)
+        return decorator
+
+    def run(self):
+        self.start()
 
     def start(self):
-        # create and run main event loop safely
         asyncio.run(self.gateway.connect())
+
+    async def close(self):
+        await self.gateway.close()
+        await self.http.close()
+
+    @staticmethod
+    def _event_name_from_handler(handler):
+        name = getattr(handler, "__name__", "ready")
+        return name[3:] if name.startswith("on_") else name
 
     async def _dispatch(self, event, data):
         if event == "MESSAGE_CREATE":
-            # safe extraction
-            author = User(id=str(data.get("author",{}).get("id","")), username=data.get("author",{}).get("username",""))
-            msg = Message(id=str(data.get("id","")), channel_id=str(data.get("channel_id","")), content=data.get("content",""), author=author, raw=data)
+            author_data = data.get("author", {})
+            author = User(
+                id=str(author_data.get("id", "")),
+                username=author_data.get("username", ""),
+                discriminator=author_data.get("discriminator", "0000"),
+                bot=author_data.get("bot", False),
+            )
+            msg = Message(
+                id=str(data.get("id", "")),
+                channel_id=str(data.get("channel_id", "")),
+                content=data.get("content", ""),
+                author=author,
+                raw=data,
+            )
             await self.cmd.run(self, msg)
             await self.events.emit("message", msg)
         elif event == "INTERACTION_CREATE":
-            # Discord interaction event for slash commands
             await self.slash.handle(self, data)
         elif event == "READY":
             await self.events.emit("ready", data)

--- a/ruythcore/context.py
+++ b/ruythcore/context.py
@@ -4,27 +4,40 @@ class Context:
         self.raw = raw
         self.is_slash = slash
         if slash:
-            # minimal safe extraction
             self.interaction_id = raw.get("id")
             self.token = raw.get("token")
-            # channel might be nested differently; try both
-            self.channel_id = (raw.get("channel",{}) or {}).get("id") or raw.get("channel_id")
+            self.channel_id = (raw.get("channel", {}) or {}).get("id") or raw.get("channel_id")
             member = raw.get("member") or {}
             user = member.get("user") or raw.get("user") or {}
-            self.author = type("U",(object,),{"id": user.get("id"), "username": user.get("username")})
+            self.author = type(
+                "U",
+                (object,),
+                {"id": user.get("id"), "username": user.get("username")},
+            )
             self.content = None
         else:
             self.interaction_id = None
             self.token = None
-            self.channel_id = raw.get("channel_id")
-            author = raw.get("author", {})
-            self.author = type("U",(object,),{"id": author.get("id"), "username": author.get("username")})
-            self.content = raw.get("content", "")
+            self.channel_id = self._get(raw, "channel_id")
+            author = self._get(raw, "author", {}) or {}
+            if isinstance(author, dict):
+                author_id = author.get("id")
+                username = author.get("username")
+            else:
+                author_id = getattr(author, "id", None)
+                username = getattr(author, "username", None)
+            self.author = type("U", (object,), {"id": author_id, "username": username})
+            self.content = self._get(raw, "content", "")
+
+    @staticmethod
+    def _get(raw, key, default=None):
+        if isinstance(raw, dict):
+            return raw.get(key, default)
+        return getattr(raw, key, default)
 
     async def reply(self, content: str):
         if self.is_slash:
-            # use interaction response
-            return await self.client.http.send_interaction_response(self.interaction_id, self.token, content)
-        else:
-            return await self.client.http.send_message(self.channel_id, content)
-        
+            return await self.client.http.send_interaction_response(
+                self.interaction_id, self.token, content
+            )
+        return await self.client.http.send_message(self.channel_id, content)

--- a/ruythcore/gateway.py
+++ b/ruythcore/gateway.py
@@ -1,6 +1,17 @@
-import asyncio, json
-import websockets
-from .constants import GATEWAY_URL, OP_HEARTBEAT, OP_IDENTIFY, OP_HEARTBEAT_ACK, OP_RECONNECT, OP_INVALID_SESSION
+import asyncio
+import json
+import importlib.util
+
+from .constants import (
+    GATEWAY_URL,
+    OP_HEARTBEAT,
+    OP_IDENTIFY,
+    OP_HEARTBEAT_ACK,
+    OP_RECONNECT,
+    OP_INVALID_SESSION,
+)
+from .http import MissingDependencyError
+
 
 class Gateway:
     def __init__(self, token, intents, dispatch):
@@ -11,58 +22,80 @@ class Gateway:
         self.heartbeat_interval = None
         self.seq = None
         self.session_id = None
-        self._task = None
         self._closing = False
 
     async def connect(self):
+        if importlib.util.find_spec("websockets") is None:
+            raise MissingDependencyError("websockets", "Discord gateway connections")
+        import websockets
+
         backoff = 1
         while not self._closing:
+            hb = None
+            listen = None
             try:
                 self.ws = await websockets.connect(GATEWAY_URL)
                 hello = json.loads(await self.ws.recv())
                 self.heartbeat_interval = hello["d"]["heartbeat_interval"] / 1000.0
                 await self.identify()
-                # start heartbeat + listen
                 hb = asyncio.create_task(self._heartbeat_loop())
                 listen = asyncio.create_task(self._listen_loop())
-                await asyncio.wait([hb, listen], return_when=asyncio.FIRST_EXCEPTION)
+                done, pending = await asyncio.wait(
+                    [hb, listen], return_when=asyncio.FIRST_EXCEPTION
+                )
+                for task in pending:
+                    task.cancel()
+                for task in done:
+                    exc = task.exception()
+                    if exc:
+                        raise exc
+            except asyncio.CancelledError:
+                self._closing = True
+                raise
             except Exception as e:
                 print("[Gateway] connection error:", e)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60)
             finally:
-                try:
-                    if self.ws:
-                        await self.ws.close()
-                except:
-                    pass
+                for task in (hb, listen):
+                    if task and not task.done():
+                        task.cancel()
+                if self.ws:
+                    await self.ws.close()
                 await asyncio.sleep(1)
 
     async def identify(self):
+        if self.ws is None:
+            raise RuntimeError("Gateway websocket is not connected")
         payload = {
             "op": OP_IDENTIFY,
             "d": {
                 "token": self.token,
                 "intents": self.intents,
-                "properties": {"$os":"linux","$browser":"ruythcore","$device":"ruythcore"}
-            }
+                "properties": {
+                    "$os": "linux",
+                    "$browser": "ruythcore",
+                    "$device": "ruythcore",
+                },
+            },
         }
         await self.ws.send(json.dumps(payload))
 
+    async def close(self):
+        self._closing = True
+        if self.ws:
+            await self.ws.close()
+
     async def _heartbeat_loop(self):
-        try:
-            while True:
-                await asyncio.sleep(self.heartbeat_interval)
-                await self.ws.send(json.dumps({"op": OP_HEARTBEAT, "d": self.seq}))
-        except Exception as e:
-            # stop heartbeat on error
-            pass
+        while not self._closing:
+            await asyncio.sleep(self.heartbeat_interval)
+            await self.ws.send(json.dumps({"op": OP_HEARTBEAT, "d": self.seq}))
 
     async def _listen_loop(self):
         async for raw in self.ws:
             try:
                 data = json.loads(raw)
-            except:
+            except json.JSONDecodeError:
                 continue
             op = data.get("op")
             t = data.get("t")
@@ -72,11 +105,10 @@ class Gateway:
             if op == OP_HEARTBEAT_ACK:
                 continue
             if op == OP_RECONNECT:
-                raise Exception("Gateway requested reconnect")
+                raise RuntimeError("Gateway requested reconnect")
             if op == OP_INVALID_SESSION:
                 await asyncio.sleep(2)
                 await self.identify()
                 continue
             if t:
-                # dispatch events to client
                 await self.dispatch(t, d)

--- a/ruythcore/http.py
+++ b/ruythcore/http.py
@@ -1,5 +1,5 @@
-import aiohttp
 import asyncio
+import importlib.util
 
 from .constants import HTTP_BASE, USER_AGENT
 
@@ -11,6 +11,19 @@ class HTTPException(Exception):
         self.message = message
 
 
+class MissingDependencyError(RuntimeError):
+    """Raised when an optional runtime dependency is required but missing."""
+
+    def __init__(self, package, feature):
+        super().__init__(
+            f"{package!r} is required to use {feature}. "
+            f"Install runtime dependencies with: pip install {package} "
+            "or pip install -r requirements.txt"
+        )
+        self.package = package
+        self.feature = feature
+
+
 class HTTPClient:
     def __init__(self, token):
         self.token = token
@@ -18,6 +31,10 @@ class HTTPClient:
 
     async def _ensure(self):
         if self._session is None or self._session.closed:
+            if importlib.util.find_spec("aiohttp") is None:
+                raise MissingDependencyError("aiohttp", "HTTP requests")
+            import aiohttp
+
             self._session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=15)
             )
@@ -34,42 +51,34 @@ class HTTPClient:
         headers = {**default_headers, **kwargs.pop("headers", {})}
         url = HTTP_BASE + path
 
-        for attempt in range(retry + 1):
+        for _ in range(retry + 1):
             async with self._session.request(
                 method,
                 url,
                 headers=headers,
                 **kwargs
             ) as resp:
-
                 text = await resp.text()
 
-                # 🔥 rate limit (Discord style)
                 if resp.status == 429:
                     try:
                         data = await resp.json()
                         retry_after = data.get("retry_after", 1)
-                    except:
+                    except Exception:
                         retry_after = 1
 
                     await asyncio.sleep(retry_after)
                     continue
 
-                # ❌ lỗi
                 if resp.status >= 400:
                     raise HTTPException(resp.status, text)
 
-                # ✅ success
                 if resp.headers.get("Content-Type", "").startswith("application/json"):
                     return await resp.json()
 
                 return text
 
         raise HTTPException(429, "Too many retries")
-
-    # =========================
-    # 📌 API HELPERS
-    # =========================
 
     async def send_message(self, channel_id, content):
         return await self.request(
@@ -114,10 +123,6 @@ class HTTPClient:
             f"/webhooks/{application_id}/{token}",
             json={"content": content},
         )
-
-    # =========================
-    # 🔧 SESSION CONTROL
-    # =========================
 
     async def close(self):
         if self._session and not self._session.closed:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,61 @@
+import asyncio
+
+import ruythcore
+from ruythcore.models import Message, User
+
+
 def test_import_main():
-    import ruythcore
+    assert ruythcore.Client is not None
+
 
 def test_client_init():
-    import ruythcore
     bot = ruythcore.Client("FAKE_TOKEN", prefix="!")
     assert bot.prefix == "!"
     assert bot.token == "FAKE_TOKEN"
-    
+
+
+def test_event_decorator_infers_on_prefix_name():
+    bot = ruythcore.Client("FAKE_TOKEN")
+
+    @bot.event
+    async def on_ready(data):
+        return data
+
+    assert bot.events.listeners["ready"] == [on_ready]
+
+
+def test_context_accepts_message_model():
+    bot = ruythcore.Client("FAKE_TOKEN")
+    msg = Message(
+        id="1",
+        channel_id="2",
+        content="!ping",
+        author=User(id="3", username="tester"),
+    )
+
+    ctx = bot.create_context(msg)
+
+    assert ctx.channel_id == "2"
+    assert ctx.content == "!ping"
+    assert ctx.author.id == "3"
+    assert ctx.author.username == "tester"
+
+
+def test_command_dispatch_builds_context_from_message_model():
+    bot = ruythcore.Client("FAKE_TOKEN", prefix="!")
+    seen = []
+
+    @bot.command("ping")
+    async def ping(ctx, *args):
+        seen.append((ctx.channel_id, ctx.author.username, args))
+
+    msg = Message(
+        id="1",
+        channel_id="2",
+        content="!ping a b",
+        author=User(id="3", username="tester"),
+    )
+
+    asyncio.run(bot.cmd.run(bot, msg))
+
+    assert seen == [("2", "tester", ("a", "b"))]


### PR DESCRIPTION
### Motivation
- Allow importing the library in minimal environments by deferring heavy network dependencies until they are actually used and providing a clear runtime error if missing. 
- Improve client ergonomics and lifecycle control so applications can register events with `@bot.event` and cleanly start/stop the `Client`. 
- Harden gateway and context code paths to avoid hangs/crashes during connect/dispatch and to accept both raw `dict` payloads and `Message`/`User` models. 

### Description
- Make `aiohttp` and `websockets` optional at import time by checking with `importlib.util.find_spec` and raise a `MissingDependencyError` with an installation hint when features are invoked without the package (changes in `ruythcore/http.py` and `ruythcore/gateway.py`). 
- Add `Client.run()` alias, `Client.close()` to gracefully close gateway/http, and an improved `@bot.event` decorator that infers event names from handler names like `on_ready` via `_event_name_from_handler` (changes in `ruythcore/client.py`). 
- Improve `_dispatch` to build full `Message`/`User` instances for command execution and event emission (change in `ruythcore/client.py`). 
- Make `Context` robust to both `dict` payloads and `Message` model instances by adding a `_get` accessor and safer author/channel extraction (change in `ruythcore/context.py`). 
- Harden gateway control flow: task coordination with `asyncio.wait`, cancel pending tasks, explicit `close()` to request shutdown, and clearer exception handling (change in `ruythcore/gateway.py`). 
- Simplify runtime `requirements.txt` to real external deps and broaden package discovery in `pyproject.toml` to `include = ["ruythcore*"]`. 
- Expand and adjust tests in `tests/test_imports.py` to cover import, client init, event decorator behavior, context from models, and command dispatch. 

### Testing
- Ran `python -m pytest -q` which passed (`5 passed`). 
- Ran `python -m compileall -q ruythcore` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50d2e15f84832aabdf0a9767e0e746)